### PR TITLE
Add .preventDefault() on scan and swipe methods

### DIFF
--- a/jquery.pos.js
+++ b/jquery.pos.js
@@ -42,6 +42,7 @@
         $this.keypress(function(event) {
             if ($this.options.scan) {
                 if (event.which == 13) {
+                    event.preventDefault();
                     var scanexp = new RegExp('^' + $this.options.prefix.scan.barcode + $this.options.regexp.scan.barcode + '$');
                     if (data.scan.match(scanexp)) {
                         $this.trigger({
@@ -59,6 +60,7 @@
 
             if ($this.options.swipe) {
                 if (event.which == 13) {
+                    event.preventDefault();
                     var swipexp = new RegExp('^' + $this.options.prefix.swipe.card + $this.options.regexp.swipe.card + '$');
                     if (data.swipe.match(swipexp)) {
                         var swipe_match = swipexp.exec(data.swipe);


### PR DESCRIPTION
Everytime we try to capture a barcode with a focused input the default action after that is to keypress enter. When working with `<form>`, this is a huge inconvenient because it will try to submit the form anyway. So here I take the keypressing response and execute a `.preventDefault()` so it won't try to enter (`keypress == 13`) anymore.

Great plugin btw, it will help me a lot.
Thanks!
